### PR TITLE
Fix taxonomy rewrite args

### DIFF
--- a/plugins/wb-custom/taxonomies/wheel-construction.php
+++ b/plugins/wb-custom/taxonomies/wheel-construction.php
@@ -21,8 +21,10 @@ function create_wheel_construction_tax() {
         'publicly_queryable' => true,
         'hierarchical'       => false, // Set to false to make it non-hierarchical like tags
         'show_ui'            => true,
-        'rewrite'            => array('slug' => 'wheel-construction'),
-        'with_front'         => true,
+        'rewrite'            => array(
+            'slug'       => 'wheel-construction',
+            'with_front' => true,
+        ),
         'show_in_menu'       => true,
         'show_admin_column'  => true,
         'show_in_nav_menus'  => true,


### PR DESCRIPTION
## Summary
- correct the rewrite configuration for the Wheel Construction taxonomy

## Testing
- `find . -name '*.php' -not -path "*/node_modules/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68760c9c95488330bbaa96f68e197907